### PR TITLE
Option to use different users and use even more apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 Easy access Jira rest api in Laravel5.
 
 * [Installation and Requirements](#installation)
+* [Getting Versions](#versions)
 * [Searching issues](#searching)
 * [Creating issues](#creating)
 * [Editing issues](#editing)
+* [Changing status or version of issues](#transitions)
 
 <a name="installation"></a>
 ## Installation and Requirements
@@ -32,6 +34,38 @@ Then, update `config/app.php` by adding an entry for the service provider.
 
 Finally, from the command line again, run `php artisan vendor:publish` to publish
 the default configuration file to config/jira.php.
+YOu can either set your credentials in the configuration file or you can enter the credentials to new created instance.
+```php
+use Univerze\Jira\Jira;
+
+$jira = new Jira("https://[yourDomain].atlassian.net/", "username", "password");
+$response = $jira->search( 'project = YourProject AND labels = somelabel' );
+```
+Alternative you can change the credentials to use afterwards.
+```php
+use Univerze\Jira\Jira;
+
+$jira = new Jira();
+$jira->url      = "https://[yourDomain].atlassian.net/";
+$jira->username = "username";
+$jira->password = "password";
+$response = $jira->search( 'project = YourProject AND labels = somelabel' );
+```
+
+<a name="versions"></a>
+## Getting versions
+
+Get all versions of a project:
+```php
+$jira = new Jira();
+$response = $jira->getVersions( 'YourProject' );
+```
+
+In addition you can request details for a specific version listed in the versions-list
+```php
+$jira = new getVersion();
+$response = $jira->getVersion( '20351' );
+```
 
 <a name="searching"></a>
 ## Searching issues
@@ -39,7 +73,8 @@ the default configuration file to config/jira.php.
 The search method will take the jql query string:
 
 ```php
-$response = Jira::search( 'project = YourProject AND labels = somelabel' );
+$jira = new Jira();
+$response = $jira->search( 'project = YourProject AND labels = somelabel' );
 ```
 
 You can build and test the jql beforehand if you go to your Jira site Issues > Search for Issues > Advanced Search.
@@ -52,7 +87,8 @@ Further information can be found on [JIRA documentation - search issues](https:/
 ## Creating issues
 
 ```php
-$issue = Jira::create( array(
+$jira = new Jira();
+$issue = $jira->create( array(
     'project'     => array(
         'key' => 'YourProject'
     ),
@@ -72,7 +108,8 @@ Further information can be found on [JIRA documentation - create issue](https://
 ## Editing issues
 
 ```php
-Jira::update( 'ISSUE-1234', array(
+$jira = new Jira();
+$jira->update( 'ISSUE-1234', array(
     'description' => 'this is my new description'
 ) );
 ```
@@ -82,6 +119,27 @@ In this case the JIRA api will return "204 - No Content" instead of issue detail
 Further information can be found on [JIRA documentation - edit issue](https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-edit-issues)
 
 > **NOTE** fields parameter is already included in the payload
+
+<a name="transitions"></a>
+## Changing status or version of issues
+
+Get all available transitions for an issue. Only transactions are listed, that are visible in context for the user
+```php
+$jira = new Jira();
+$jira->getTransitions( 'ISSUE-1234') );
+```
+
+If you want to change the status of an issue you have to execute a available transition. Tha available transitions you can get with getTransitions
+```php
+$jira = new Jira();
+$jira->doTransitions( 'ISSUE-1234', '3') );
+```
+
+You can move an issue to another version
+```php
+$jira = new Jira();
+$jira->updateVersion( 'ISSUE-1234', '20351') );
+```
 
 ---
 

--- a/src/Jira.php
+++ b/src/Jira.php
@@ -83,6 +83,18 @@ class Jira
     }
 
     /**
+     * Create function for getting all statuses of a project
+     *
+     * @param string $projectName
+     * @return mixed
+     */
+    public function getStatuses( $projectName )
+    {
+        $result = self::request('project/' . $projectName . "/statuses");
+        return json_decode($result);
+    }
+
+    /**
      * Create function for getting details of a version
      *
      * @param string $versionId

--- a/src/Jira.php
+++ b/src/Jira.php
@@ -77,7 +77,7 @@ class Jira
      */
     public function getVersions( $projectName )
     {
-        $result = self::request('project/' . $projectName . "/versions")
+        $result = self::request('project/' . $projectName . "/versions",[]);
 
         return json_decode($result);
     }
@@ -103,7 +103,7 @@ class Jira
      */
     public function getVersionRelatedIssueCount( $versionId )
     {
-        $result = self::request('version/' . $versionId . "/relatedIssueCounts");
+        $result = self::request('version/' . $versionId . "/relatedIssueCounts", []);
 
         return json_decode($result);
     }
@@ -116,7 +116,7 @@ class Jira
      */
     public function getVersionUnresolvedIssueCount( $versionId )
     {
-        $result = self::request('version/' . $versionId . "/relatedIssueCounts");
+        $result = self::request('version/' . $versionId . "/unresolvedIssueCount", []);
 
         return json_decode($result);
     }

--- a/src/Jira.php
+++ b/src/Jira.php
@@ -77,7 +77,7 @@ class Jira
      */
     public function getVersions( $projectName )
     {
-        $result = self::request('project/' . $projectName . "/versions",[]);
+        $result = self::request('project/' . $projectName . "/versions");
 
         return json_decode($result);
     }

--- a/src/Jira.php
+++ b/src/Jira.php
@@ -4,19 +4,164 @@ namespace Univerze\Jira;
 
 class Jira
 {
+    /**
+     * Url of the jira including https://
+     * @var string 
+     */
+    var $url;
+
+    /**
+     * Username for theaccess
+     * @var string 
+     */
+    var $username;
+
+    /**
+     * Password of the user
+     * @var string 
+     */
+    var $password;
+
+    /**
+     * Search function to search issues with JQL string
+     *
+     * @param null $url
+     * @param null $username
+     * @param null $password
+     * @return void
+     */
+    public function __construct( $url = null, $username = null, $password = null ) {
+        if ( is_null($url) )
+        {
+            $this->url = config('jira.url');
+        }
+        if ( is_null($username) )
+        {
+            $this->username = config('jira.username');
+        }
+        if ( is_null($password) )
+        {
+            $this->password = config('jira.password');
+        }
+    }
 
     /**
      * Search function to search issues with JQL string
      *
      * @param null $jql
+     * @param false $returnAll
+     * @param int $startAt
+     * @param int $maxResults
      * @return mixed
      */
-    public static function search( $jql = NULL )
+    public function search( $jql = NULL, $returnAll = false, $startAt = 0, $maxResults = 50 )
     {
-        $data   = json_encode( array( 'jql' => $jql ) );
-        $result = self::request( 'search', $data );
+        $data   = json_encode(array('jql' => $jql, 'startAt' => $startAt, 'maxResults' => $maxResults));
+        $result = self::request('search', $data);
+        $result = json_decode($result);
+        if( $returnAll && $result->total > $result->startAt + $result->maxResults ) {
+            $nextPageIssues = $this->search($jql, true, $startAt + $maxResults, $maxResults);
+            foreach ( $nextPageIssues->issues as $issue ) {
+                $result->issues[] = $issue;
+            }
+            $result->total = count( $result->issues );
+        }
+        return $result;
+    }
 
-        return json_decode( $result );
+    /**
+     * Create function for getting all versions of a project
+     *
+     * @param string $projectName
+     * @return mixed
+     */
+    public function getVersions( $projectName )
+    {
+        $result = self::request('project/' . $projectName . "/versions")
+
+        return json_decode($result);
+    }
+
+    /**
+     * Create function for getting details of a version
+     *
+     * @param string $versionId
+     * @return mixed
+     */
+    public function getVersion( $versionId )
+    {
+        $result = self::request('version/' . $versionId);
+
+        return json_decode($result);
+    }
+
+    /**
+     * Create function for getting count of related issues for a version
+     *
+     * @param string $versionId
+     * @return mixed
+     */
+    public function getVersionRelatedIssueCount( $versionId )
+    {
+        $result = self::request('version/' . $versionId . "/relatedIssueCounts");
+
+        return json_decode($result);
+    }
+
+    /**
+     * Create function for getting count of unresolved issues for a version
+     *
+     * @param string $versionId
+     * @return mixed
+     */
+    public function getVersionUnresolvedIssueCount( $versionId )
+    {
+        $result = self::request('version/' . $versionId . "/relatedIssueCounts");
+
+        return json_decode($result);
+    }
+
+    /**
+     * Create function for getting all translations for an issue in context to the user
+     *
+     * @param string $issueId
+     * @return mixed
+     */
+    public function getTransitions( $issueId )
+    {
+        $result = self::request('issue/' . $issueId . "/transitions");
+
+        return json_decode($result);
+    }
+
+    /**
+     * Create function for doing a transition on an issue
+     *
+     * @param string $issueId
+     * @param string $transitionId
+     * @return mixed
+     */
+    public function doTransitions( $issueId, $transitionId )
+    {
+        $data   = json_encode(array('transition' => ["id" => $transitionId]));
+        $result = self::request('issue/' . $issueId . "/transitions", $data, 1);
+
+        return json_decode($result);
+    }
+
+    /**
+     * Update function to set a new fixVersion for an issue
+     *
+     * @param string $issueId
+     * @param string $versionId
+     * @return mixed
+     */
+    public function updateVersion( $issueId, $versionId )
+    {
+        $data = json_encode(["update" => ["fixVersions" => [["set" => [["id" => $versionId]]]]]]);
+        $result = self::request('issue/' . $issueId, $data, false, true);
+
+        return json_decode($result);
     }
 
     /**
@@ -25,10 +170,10 @@ class Jira
      * @param array $data
      * @return mixed
      */
-    public static function create( array $data )
+    public function create( array $data )
     {
         $data   = json_encode( array( 'fields' => $data ) );
-        $result = self::request( 'issue', $data, 1 );
+        $result = self::request( 'issue', $data, true );
 
         return json_decode( $result );
     }
@@ -40,10 +185,10 @@ class Jira
      * @param array $data
      * @return mixed
      */
-    public static function update( $issue, array $data )
+    public function update( $issue, array $data )
     {
         $data   = json_encode( array( 'fields' => $data ) );
-        $result = self::request( 'issue/' . $issue, $data, 0, 1 );
+        $result = self::request( 'issue/' . $issue, $data, false, true );
 
         return json_decode( $result );
     }
@@ -52,22 +197,25 @@ class Jira
      * CURL request to the JIRA REST api (v2)
      *
      * @param $request
-     * @param $data
+     * @param null $data
      * @param int $is_post
      * @param int $is_put
      * @return mixed
      */
-    private static function request( $request, $data, $is_post = 0, $is_put = 0 )
+    private function request( $request, $data = null, $is_post = 0, $is_put = 0 )
     {
         $ch = curl_init();
 
         curl_setopt_array( $ch, array(
-            CURLOPT_URL            => config( 'jira.url' ) . '/rest/api/2/' . $request,
-            CURLOPT_USERPWD        => config( 'jira.username' ) . ':' . config( 'jira.password' ),
-            CURLOPT_POSTFIELDS     => $data,
+            CURLOPT_URL            => $this->url . '/rest/api/2/' . $request,
+            CURLOPT_USERPWD        => $this->username . ':' . $this->password,
             CURLOPT_HTTPHEADER     => array( 'Content-type: application/json' ),
             CURLOPT_RETURNTRANSFER => 1,
         ) );
+        if( is_null($data) )
+        {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+        }
 
         if( $is_post )
         {

--- a/src/Jira.php
+++ b/src/Jira.php
@@ -103,7 +103,7 @@ class Jira
      */
     public function getVersionRelatedIssueCount( $versionId )
     {
-        $result = self::request('version/' . $versionId . "/relatedIssueCounts", []);
+        $result = self::request('version/' . $versionId . "/relatedIssueCounts");
 
         return json_decode($result);
     }
@@ -116,7 +116,7 @@ class Jira
      */
     public function getVersionUnresolvedIssueCount( $versionId )
     {
-        $result = self::request('version/' . $versionId . "/unresolvedIssueCount", []);
+        $result = self::request('version/' . $versionId . "/unresolvedIssueCount");
 
         return json_decode($result);
     }
@@ -212,7 +212,7 @@ class Jira
             CURLOPT_HTTPHEADER     => array( 'Content-type: application/json' ),
             CURLOPT_RETURNTRANSFER => 1,
         ) );
-        if( is_null($data) )
+        if( !is_null($data) )
         {
             curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
         }

--- a/src/JiraServiceProvider.php
+++ b/src/JiraServiceProvider.php
@@ -27,9 +27,8 @@ class JiraServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom( __DIR__ . '/config/jira.php', 'jira' );
 
-        $this->app['jira'] = $this->app->share( function ( $app )
-        {
-            return new Jira;
-        } );
+        $this->app->bind('jira', function () {
+            return new Jira();
+        });
     }
 }


### PR DESCRIPTION
@univerze 
If created a PR for some features I've needed for a project. LIke stated in #1 this is a very useful addition. To accomplish this I have changed the API of the Jira class a little bit. Instead of calling class-methods it now works with instance-methods. This helps using different users with different projects.

Small changelog:
- Search can now return more than 50 results for an jql
- FixVersion can me changed for an issue
- The status can be changed through transitions
- You can get all possible transitions for an issue
- Also you can get all versions of a project and in addition also some details about a specific version

Hopefully this can be merged, I was trying to adjust code style to the existing code.
Kind regards
