### PR TITLE
Update to JiraServiceProvider to fix issues with Laravel 5.4

### DIFF
--- a/src/JiraServiceProvider.php
+++ b/src/JiraServiceProvider.php
@@ -27,7 +27,7 @@ class JiraServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom( __DIR__ . '/config/jira.php', 'jira' );
 
-        $this->app['jira'] = $this->app->share( function ( $app )
+        $this->app['jira'] = $this->app->singleton( 'jira', function ( $app )
         {
             return new Jira;
         } );


### PR DESCRIPTION
As of laravel 5.4 share has been removed. You will have to use the singleton instead.